### PR TITLE
Enables testing with more Lua versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ env:
   global:
     - LUAROCKS=2.2.2
   matrix:
-    # - LUA=lua5.1
-    # - LUA=lua5.2
+    - LUA=lua5.1
+    - LUA=lua5.2
     - LUA=lua5.3
-    # - LUA=luajit     # latest stable version (2.0.4)
-    # - LUA=luajit2.0  # current head of 2.0 branch
+    - LUA=luajit     # latest stable version (2.0.4)
+    - LUA=luajit2.0  # current head of 2.0 branch
     # - LUA=luajit2.1  # current head of 2.1 branch
 
 services:

--- a/elasticsearch-scm-0.rockspec
+++ b/elasticsearch-scm-0.rockspec
@@ -12,7 +12,7 @@ description = {
   license = "Apache 2"
 }
 dependencies = {
-  "lua >= 5.3",
+  "lua >= 5.1, < 5.4",
   "luasocket",
   "lua-cjson",
   "lunitx"

--- a/tests/run-tests.lua
+++ b/tests/run-tests.lua
@@ -1,4 +1,4 @@
-lunit = require "lunitx"
+lunit = require "lunit"
 
 package.path = package.path .. ";../elasticsearch/?.lua"
 
@@ -9,3 +9,5 @@ require "selector.RoundRobinSelectorTest"
 require "selector.StickyRoundRobinSelectorTest"
 require "connectionpool.StaticConnectionPoolTest"
 require "TransportTest"
+
+lunit.main(arg)

--- a/tests/run-tests.lua
+++ b/tests/run-tests.lua
@@ -10,4 +10,14 @@ require "selector.StickyRoundRobinSelectorTest"
 require "connectionpool.StaticConnectionPoolTest"
 require "TransportTest"
 
-lunit.main(arg)
+
+local _, emsg = xpcall(function()
+	lunit.main(arg)
+end, debug.traceback)
+if emsg then
+	print(emsg)
+	os.exit(1)
+end
+if lunit.stats.failed > 0 or lunit.stats.errors > 0 then
+	os.exit(1)
+end


### PR DESCRIPTION
It turns out that the code works with no issues on Lua 5.1, Lua 5.2 and also LuaJIT.

Expand the build matrix on Travis accordingly.

To get this to work with Lua 5.1 I had to change the way lunitx is used.
By default, it does a too clever trick to run the whole test suite off an "atexit" handler.
It works fine with Lua 5.2 and 5.3, but it causes a segfault on 5.1 and LuaJIT.
(It took me the whole afternoon until I figured that out).

Now, the test suit is run explicitly.
