### PR TITLE
Request method now can be overload in config

### DIFF
--- a/src/elasticsearch/Settings.lua
+++ b/src/elasticsearch/Settings.lua
@@ -32,6 +32,9 @@ Settings.hosts = {
 
 Settings.params = {}
 
+-- The standard requester
+Settings.params.preferred_engine = 'default'
+
 -- The ping timeout
 Settings.params.pingTimeout = 1
 
@@ -149,7 +152,8 @@ function Settings:setConnectionSettings()
       host = host.host,
       port = host.port,
       pingTimeout = self.params.pingTimeout,
-      logger = self.logger
+      logger = self.logger,
+      preferred_engine = self.params.preferred_engine
     })
   end
 end


### PR DESCRIPTION
it looks like the elastic search library uses lua socket directly, so it will block the nginx worker (using it in nginx) when it runs queries. This patch provides support for openresty, using openresty's co-socket api to do non-blocking requests to the elastic search server
An example can be found here:
https://github.com/CriztianiX/lapis-elasticsearch/blob/master/lapis/db/elasticsearch.lua#L16
